### PR TITLE
Fix RA4M1 ICU IRQCR layout

### DIFF
--- a/pac/ra4m1-pac/src/icu.rs
+++ b/pac/ra4m1-pac/src/icu.rs
@@ -40,11 +40,131 @@ impl super::Icu {
         &self,
     ) -> &'static crate::common::ClusterRegisterArray<
         crate::common::Reg<self::Irqcr_SPEC, crate::common::RW>,
-        2,
+        16,
         0x1,
     > {
         unsafe {
-            crate::common::ClusterRegisterArray::from_ptr(self._svd2pac_as_ptr().add(0xeusize))
+            crate::common::ClusterRegisterArray::from_ptr(self._svd2pac_as_ptr().add(0x0usize))
+        }
+    }
+    #[inline(always)]
+    pub const fn irqcr0(&self) -> &'static crate::common::Reg<self::Irqcr_SPEC, crate::common::RW> {
+        unsafe {
+            crate::common::Reg::<self::Irqcr_SPEC, crate::common::RW>::from_ptr(
+                self._svd2pac_as_ptr().add(0x0usize),
+            )
+        }
+    }
+    #[inline(always)]
+    pub const fn irqcr1(&self) -> &'static crate::common::Reg<self::Irqcr_SPEC, crate::common::RW> {
+        unsafe {
+            crate::common::Reg::<self::Irqcr_SPEC, crate::common::RW>::from_ptr(
+                self._svd2pac_as_ptr().add(0x1usize),
+            )
+        }
+    }
+    #[inline(always)]
+    pub const fn irqcr2(&self) -> &'static crate::common::Reg<self::Irqcr_SPEC, crate::common::RW> {
+        unsafe {
+            crate::common::Reg::<self::Irqcr_SPEC, crate::common::RW>::from_ptr(
+                self._svd2pac_as_ptr().add(0x2usize),
+            )
+        }
+    }
+    #[inline(always)]
+    pub const fn irqcr3(&self) -> &'static crate::common::Reg<self::Irqcr_SPEC, crate::common::RW> {
+        unsafe {
+            crate::common::Reg::<self::Irqcr_SPEC, crate::common::RW>::from_ptr(
+                self._svd2pac_as_ptr().add(0x3usize),
+            )
+        }
+    }
+    #[inline(always)]
+    pub const fn irqcr4(&self) -> &'static crate::common::Reg<self::Irqcr_SPEC, crate::common::RW> {
+        unsafe {
+            crate::common::Reg::<self::Irqcr_SPEC, crate::common::RW>::from_ptr(
+                self._svd2pac_as_ptr().add(0x4usize),
+            )
+        }
+    }
+    #[inline(always)]
+    pub const fn irqcr5(&self) -> &'static crate::common::Reg<self::Irqcr_SPEC, crate::common::RW> {
+        unsafe {
+            crate::common::Reg::<self::Irqcr_SPEC, crate::common::RW>::from_ptr(
+                self._svd2pac_as_ptr().add(0x5usize),
+            )
+        }
+    }
+    #[inline(always)]
+    pub const fn irqcr6(&self) -> &'static crate::common::Reg<self::Irqcr_SPEC, crate::common::RW> {
+        unsafe {
+            crate::common::Reg::<self::Irqcr_SPEC, crate::common::RW>::from_ptr(
+                self._svd2pac_as_ptr().add(0x6usize),
+            )
+        }
+    }
+    #[inline(always)]
+    pub const fn irqcr7(&self) -> &'static crate::common::Reg<self::Irqcr_SPEC, crate::common::RW> {
+        unsafe {
+            crate::common::Reg::<self::Irqcr_SPEC, crate::common::RW>::from_ptr(
+                self._svd2pac_as_ptr().add(0x7usize),
+            )
+        }
+    }
+    #[inline(always)]
+    pub const fn irqcr8(&self) -> &'static crate::common::Reg<self::Irqcr_SPEC, crate::common::RW> {
+        unsafe {
+            crate::common::Reg::<self::Irqcr_SPEC, crate::common::RW>::from_ptr(
+                self._svd2pac_as_ptr().add(0x8usize),
+            )
+        }
+    }
+    #[inline(always)]
+    pub const fn irqcr9(&self) -> &'static crate::common::Reg<self::Irqcr_SPEC, crate::common::RW> {
+        unsafe {
+            crate::common::Reg::<self::Irqcr_SPEC, crate::common::RW>::from_ptr(
+                self._svd2pac_as_ptr().add(0x9usize),
+            )
+        }
+    }
+    #[inline(always)]
+    pub const fn irqcr10(
+        &self,
+    ) -> &'static crate::common::Reg<self::Irqcr_SPEC, crate::common::RW> {
+        unsafe {
+            crate::common::Reg::<self::Irqcr_SPEC, crate::common::RW>::from_ptr(
+                self._svd2pac_as_ptr().add(0xausize),
+            )
+        }
+    }
+    #[inline(always)]
+    pub const fn irqcr11(
+        &self,
+    ) -> &'static crate::common::Reg<self::Irqcr_SPEC, crate::common::RW> {
+        unsafe {
+            crate::common::Reg::<self::Irqcr_SPEC, crate::common::RW>::from_ptr(
+                self._svd2pac_as_ptr().add(0xbusize),
+            )
+        }
+    }
+    #[inline(always)]
+    pub const fn irqcr12(
+        &self,
+    ) -> &'static crate::common::Reg<self::Irqcr_SPEC, crate::common::RW> {
+        unsafe {
+            crate::common::Reg::<self::Irqcr_SPEC, crate::common::RW>::from_ptr(
+                self._svd2pac_as_ptr().add(0xcusize),
+            )
+        }
+    }
+    #[inline(always)]
+    pub const fn irqcr13(
+        &self,
+    ) -> &'static crate::common::Reg<self::Irqcr_SPEC, crate::common::RW> {
+        unsafe {
+            crate::common::Reg::<self::Irqcr_SPEC, crate::common::RW>::from_ptr(
+                self._svd2pac_as_ptr().add(0xdusize),
+            )
         }
     }
     #[inline(always)]

--- a/pac/ra4m1-pac/src/reg_name.rs
+++ b/pac/ra4m1-pac/src/reg_name.rs
@@ -4127,6 +4127,12 @@ static REGISTER_NAMES: phf::Map<u64, &'static str> = phf_map! {
   0x40040d03u64 => "
       PMISC.pwpr(),
     ",
+  0x40006000u64 => "
+      ICU.irqcr()[0],
+    ",
+  0x40006001u64 => "
+      ICU.irqcr()[1],
+    ",
   0x40006002u64 => "
       ICU.irqcr()[2],
     ",
@@ -4160,11 +4166,14 @@ static REGISTER_NAMES: phf::Map<u64, &'static str> = phf_map! {
   0x4000600cu64 => "
       ICU.irqcr()[12],
     ",
+  0x4000600du64 => "
+      ICU.irqcr()[13],
+    ",
   0x4000600eu64 => "
-      ICU.irqcr()[0],
+      ICU.irqcr()[14],
     ",
   0x4000600fu64 => "
-      ICU.irqcr()[1],
+      ICU.irqcr()[15],
     ",
   0x40006140u64 => "
       ICU.nmisr(),

--- a/scripts/preprocess_svd_for_svd2pac.py
+++ b/scripts/preprocess_svd_for_svd2pac.py
@@ -1,0 +1,49 @@
+#!/usr/bin/env python3
+
+import argparse
+import pathlib
+import re
+import sys
+
+
+ENUM_BLOCK_RE = re.compile(r"<enumeratedValue>.*?</enumeratedValue>", re.DOTALL)
+EMPTY_ENUM_VALUES_RE = re.compile(
+    r"\s*<enumeratedValues>\s*</enumeratedValues>", re.DOTALL
+)
+
+
+def strip_default_only_enum_blocks(text: str) -> tuple[str, int]:
+    removed = 0
+
+    def repl(match: re.Match[str]) -> str:
+        nonlocal removed
+        block = match.group(0)
+        if "<isDefault>true</isDefault>" in block and "<value>" not in block:
+            removed += 1
+            return ""
+        return block
+
+    return ENUM_BLOCK_RE.sub(repl, text), removed
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Preprocess a Renesas SVD into a form stock svd2pac can ingest."
+    )
+    parser.add_argument("input", type=pathlib.Path)
+    parser.add_argument("output", type=pathlib.Path)
+    args = parser.parse_args()
+
+    text = args.input.read_text(encoding="utf-8")
+    processed, removed = strip_default_only_enum_blocks(text)
+    processed, empty_removed = EMPTY_ENUM_VALUES_RE.subn("", processed)
+
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    args.output.write_text(processed, encoding="utf-8")
+    print(f"removed_default_only_enum_blocks={removed}", file=sys.stderr)
+    print(f"removed_empty_enumerated_values={empty_removed}", file=sys.stderr)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/svd/R7FA4M1AB.svd
+++ b/svd/R7FA4M1AB.svd
@@ -19532,117 +19532,12 @@ These bits select the peripheral function. For individual pin functions, see the
             </interrupt>
             <registers>
                 <register>
-                    <dim>13</dim>
+                    <dim>16</dim>
                     <dimIncrement>0x1</dimIncrement>
-                    <dimIndex>0-12</dimIndex>
+                    <dimIndex>0-15</dimIndex>
                     <name>IRQCR%s</name>
                     <description>IRQ Control Register %s</description>
                     <addressOffset>0x000</addressOffset>
-                    <size>8</size>
-                    <access>read-write</access>
-                    <resetValue>0x00</resetValue>
-                    <resetMask>0xFF</resetMask>
-                    <fields>
-                        <field>
-                            <name>FLTEN</name>
-                            <description>IRQ Digital Filter Enable</description>
-                            <lsb>7</lsb>
-                            <msb>7</msb>
-                            <access>read-write</access>
-                            <enumeratedValues>
-                                <enumeratedValue>
-                                    <name>0</name>
-                                    <description>Digital filter disabled.</description>
-                                    <value>#0</value>
-                                </enumeratedValue>
-                                <enumeratedValue>
-                                    <name>1</name>
-                                    <description>Digital filter enabled.</description>
-                                    <value>#1</value>
-                                </enumeratedValue>
-                            </enumeratedValues>
-                        </field>
-                        <field>
-                            <name>Reserved</name>
-                            <description>This bit is read as 0. The write value should be 0.</description>
-                            <lsb>6</lsb>
-                            <msb>6</msb>
-                            <access>read-write</access>
-                        </field>
-                        <field>
-                            <name>FCLKSEL</name>
-                            <description>IRQ Digital Filter Sampling Clock Select</description>
-                            <lsb>4</lsb>
-                            <msb>5</msb>
-                            <access>read-write</access>
-                            <enumeratedValues>
-                                <enumeratedValue>
-                                    <name>00</name>
-                                    <description>PCLKB</description>
-                                    <value>#00</value>
-                                </enumeratedValue>
-                                <enumeratedValue>
-                                    <name>01</name>
-                                    <description>PCLKB/8</description>
-                                    <value>#01</value>
-                                </enumeratedValue>
-                                <enumeratedValue>
-                                    <name>10</name>
-                                    <description>PCLKB/32</description>
-                                    <value>#10</value>
-                                </enumeratedValue>
-                                <enumeratedValue>
-                                    <name>11</name>
-                                    <description>PCLKB/64</description>
-                                    <value>#11</value>
-                                </enumeratedValue>
-                            </enumeratedValues>
-                        </field>
-                        <field>
-                            <name>Reserved</name>
-                            <description>These bits are read as 00. The write value should be 00.</description>
-                            <lsb>2</lsb>
-                            <msb>3</msb>
-                            <access>read-write</access>
-                        </field>
-                        <field>
-                            <name>IRQMD</name>
-                            <description>IRQ Detection Sense Select</description>
-                            <lsb>0</lsb>
-                            <msb>1</msb>
-                            <access>read-write</access>
-                            <enumeratedValues>
-                                <enumeratedValue>
-                                    <name>00</name>
-                                    <description>Falling edge</description>
-                                    <value>#00</value>
-                                </enumeratedValue>
-                                <enumeratedValue>
-                                    <name>01</name>
-                                    <description>Rising edge</description>
-                                    <value>#01</value>
-                                </enumeratedValue>
-                                <enumeratedValue>
-                                    <name>10</name>
-                                    <description>Rising and falling edges</description>
-                                    <value>#10</value>
-                                </enumeratedValue>
-                                <enumeratedValue>
-                                    <name>11</name>
-                                    <description>Low level</description>
-                                    <value>#11</value>
-                                </enumeratedValue>
-                            </enumeratedValues>
-                        </field>
-                    </fields>
-                </register>
-                <register>
-                    <dim>2</dim>
-                    <dimIncrement>0x1</dimIncrement>
-                    <dimIndex>14,15</dimIndex>
-                    <name>IRQCR%s</name>
-                    <description>IRQ Control Register %s</description>
-                    <addressOffset>0x00E</addressOffset>
                     <size>8</size>
                     <access>read-write</access>
                     <resetValue>0x00</resetValue>


### PR DESCRIPTION
The RA4M1 ICU SVD modeled IRQCR as channels 0-12 at offset 0x000 and channels 14-15 at offset 0x00e, which dropped IRQCR13 and caused the generated PAC to map irqcr()[0] and irqcr()[1] to 0x4000600e/0x4000600f instead of 0x40006000/0x40006001.

That broke real IRQ0 button configuration on EK-RA4M1 and forced raw register writes in downstream code. Update the RA4M1 SVD and generated PAC so IRQCR is a contiguous 16-byte array at offset 0x000, with reg_name entries that match the hardware layout.

Also add a small preprocess helper that strips unsupported default-only enumerated values from Renesas SVDs so stock svd2pac 0.6.1 can regenerate the RA4M1 PAC from a cleaned SVD copy.